### PR TITLE
Update main.go templates for different app types

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,9 +4,9 @@ Copyright © 2024 Elouan DA COSTA PEIXOTO elouandacostapeixoto@gmail.com
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"log"
+	"microservice-cli/templates"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -159,10 +159,13 @@ func addPackageToApp(appType string, newAppBasePath string) {
 	exec.Command("touch", "main.go").Output()
 	if appType == "gin" {
 		exec.Command("go", "get", "-u", "github.com/gin-gonic/gin@latest").Output()
-		writeInMainGo(newAppBasePath)
+		writeGinMainGo(newAppBasePath)
 	}
 	if appType == "gRPC" {
 		exec.Command("go", "get", "-u", "google.golang.org/grpc").Output()
+	}
+	if appType == "basic http" {
+		writeHttpMainGo(newAppBasePath)
 	}
 }
 
@@ -189,25 +192,42 @@ func writeInSaveAppFile(appName string, basePath string) {
 	f.Close()
 }
 
-func writeInMainGo(basePath string) {
+func writeHttpMainGo(basePath string) {
+	os.Chdir(basePath)
+	f, err := os.OpenFile("main.go", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	content := fmt.Sprintf(templates.RenderHttpTemplate())
+
+	_, err = f.WriteString(content)
+
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println("main.go generated successfully.")
+	}
+}
+
+func writeGinMainGo(basePath string) {
 	// Write the string to the file
 	os.Chdir(basePath)
 	f, err := os.OpenFile("main.go", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return
 	}
-	writer := bufio.NewWriter(f)
 
-	writer.WriteString("package main\n\n")
-	writer.WriteString(`import "github.com/gin-gonic/gin"`)
-	writer.WriteString("\n\nfunc main() {\n")
-	writer.WriteString("\tr := gin.Default()\n")
-	writer.WriteString(`  r.GET("/ping", func(c *gin.Context) {`)
-	writer.WriteString("\n\t\tc.JSON(200, gin.H{\n")
-	writer.WriteString(`      "message": "pong",`)
-	writer.WriteString("\n\t\t})\n\t})\n\tr.Run()\n}\n")
+	content := fmt.Sprintf(templates.RenderGinTemplate())
 
-	writer.Flush()
+	_, err = f.WriteString(content)
+
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println("main.go generated successfully.")
+	}
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -159,13 +159,14 @@ func addPackageToApp(appType string, newAppBasePath string) {
 	exec.Command("touch", "main.go").Output()
 	if appType == "gin" {
 		exec.Command("go", "get", "-u", "github.com/gin-gonic/gin@latest").Output()
-		writeGinMainGo(newAppBasePath)
+		writeMainGo(newAppBasePath, "gin")
 	}
 	if appType == "gRPC" {
 		exec.Command("go", "get", "-u", "google.golang.org/grpc").Output()
+		writeMainGo(newAppBasePath, "gRPC")
 	}
 	if appType == "basic http" {
-		writeHttpMainGo(newAppBasePath)
+		writeMainGo(newAppBasePath, "basic http")
 	}
 }
 
@@ -192,7 +193,7 @@ func writeInSaveAppFile(appName string, basePath string) {
 	f.Close()
 }
 
-func writeHttpMainGo(basePath string) {
+func writeMainGo(basePath string, appType string) {
 	os.Chdir(basePath)
 	f, err := os.OpenFile("main.go", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
@@ -200,26 +201,16 @@ func writeHttpMainGo(basePath string) {
 		return
 	}
 
-	content := fmt.Sprintf(templates.RenderHttpTemplate())
+	content := ""
 
-	_, err = f.WriteString(content)
-
-	if err != nil {
-		fmt.Println(err)
-	} else {
-		fmt.Println("main.go generated successfully.")
+	switch appType {
+	case "gin":
+		content = fmt.Sprintf(templates.RenderGinTemplate())
+	case "gRPC":
+		content = fmt.Sprintf(templates.RenderGrpcTemplate())
+	case "basic http":
+		content = fmt.Sprintf(templates.RenderHttpTemplate())
 	}
-}
-
-func writeGinMainGo(basePath string) {
-	// Write the string to the file
-	os.Chdir(basePath)
-	f, err := os.OpenFile("main.go", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return
-	}
-
-	content := fmt.Sprintf(templates.RenderGinTemplate())
 
 	_, err = f.WriteString(content)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.5",
+	Version: "0.9",
 	Use:     "microservice-cli",
 	Short:   "Generate a basic template of microservice in Golang",
 	Long:    `Generate template for microservice in Golang with the package that you want, like gin, gRPC etc.`,

--- a/templates/main-gin.template.go
+++ b/templates/main-gin.template.go
@@ -1,0 +1,20 @@
+package templates
+
+func RenderGinTemplate() string {
+	const mainTemplate = `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	r.GET("/ping", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"message": "pong",
+		})
+	})
+	r.Run()
+}
+	`
+
+	return mainTemplate
+}

--- a/templates/main-grpc.template.go
+++ b/templates/main-grpc.template.go
@@ -1,0 +1,29 @@
+package templates
+
+func RenderGrpcTemplate() string {
+	const mainTemplate = `package main
+
+import (
+"log"
+"net"
+
+"google.golang.org/grpc"
+)
+
+func main() {
+
+	lis, err := net.Listen("tcp", ":9000")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	grpcServer := grpc.NewServer()
+
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %s", err)
+	}
+}
+	`
+
+	return mainTemplate
+}

--- a/templates/main-http.template.go
+++ b/templates/main-http.template.go
@@ -1,0 +1,28 @@
+package templates
+
+func RenderHttpTemplate() string {
+	const mainTemplate = `package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func getHello(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("got /hello request\n")
+	io.WriteString(w, "Hello, HTTP!\n")
+}
+
+func main() {
+	http.HandleFunc("/hello", getHello)
+
+	err := http.ListenAndServe(":3333", nil)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+	`
+
+	return mainTemplate
+}


### PR DESCRIPTION
This pull request updates the main.go templates for different app types. It adds templates for the generated main.go file and updates the function to generate the main.go file in init.go. The templates include a template for a Gin app, a gRPC app, and a basic HTTP app. This allows users to easily generate a basic template for their microservice in Golang with the package of their choice.