### PR TITLE
Update CLI name and descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 bin
+go-app-cli
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.so
 *.dylib
 bin
-go-app-cli
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,11 +5,12 @@ package cmd
 
 import (
 	"fmt"
-	"go-app-cli/templates"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/ElouanDaCosta/Golang-application-cli/templates"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,8 +5,8 @@ package cmd
 
 import (
 	"fmt"
+	"go-app-cli/templates"
 	"log"
-	"microservice-cli/templates"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +36,11 @@ type promptContent struct {
 var generateCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a golang application.",
-	Long:  `Initialize a golang application using the specified technology between gin, gRPC or just basic http.`,
+	Long: `Initialize a golang application using the specified technology between gin, gRPC or just basic http. For example:
+
+go-app-cli init 
+go-app-cli init --name [your_app_name]
+	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		appName, _ := cmd.Flags().GetString("name")
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,7 +16,10 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List generated application.",
-	Long:  `List all generated application or one application by name.`,
+	Long: `List all generated application or one application by name. For example:
+go-app-cli list
+go-app-cli list --name [your_app_name]
+	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		appName, _ := cmd.Flags().GetString("name")
 
@@ -54,5 +57,5 @@ func getOneApp(appName string) {
 
 func init() {
 	rootCmd.AddCommand(listCmd)
-	listCmd.PersistentFlags().String("name", "", "Return the app with the given name (default new_app)")
+	listCmd.PersistentFlags().String("name", "", "Return the app with the given name")
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -20,7 +20,7 @@ var removeCmd = &cobra.Command{
 	Short: "Remove an application from the storage",
 	Long: `Remove an application from the storage,
 clear completely the storage where all the application is saved 
-or remove an application with the rf flag. For example:
+or remove an application with the remove-app flag. For example:
 
 go-app-cli remove --name new_app
 go-app-cli remove --prune

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,9 +12,9 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Version: "0.9",
-	Use:     "microservice-cli",
-	Short:   "Generate a basic template of microservice in Golang",
-	Long:    `Generate template for microservice in Golang with the package that you want, like gin, gRPC etc.`,
+	Use:     "go-app-cli",
+	Short:   "Generate a basic template of an application in Golang",
+	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
@@ -38,5 +38,4 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -17,11 +17,11 @@ var upgradeCmd = &cobra.Command{
 	Short: "Upgrade the go version of the specified application.",
 	Long: `Upgrade a single application go version or a specified package version or update all applications go version or package. For example:
 
-go-app-cli upgrade --name new_app --newversion 1.23
+go-app-cli upgrade --name [your_app_name] --newversion [version_wanted]
 
-go-app-cli upgrade --newversion 1.23 --all-application
+go-app-cli upgrade --newversion [version_wanted] --all-application
 
-go-app-cli upgrade --newversion 1.23 -a
+go-app-cli upgrade --newversion [version_wanted] -a
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module microservice-cli
+module go-app-cli
 
 go 1.22.5
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-app-cli
+module github.com/ElouanDaCosta/Golang-application-cli
 
 go 1.22.5
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ Copyright © 2024 Elouan DA COSTA PEIXOTO
 */
 package main
 
-import "microservice-cli/cmd"
+import "go-app-cli/cmd"
 
 func main() {
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ Copyright © 2024 Elouan DA COSTA PEIXOTO
 */
 package main
 
-import "go-app-cli/cmd"
+import "github.com/ElouanDaCosta/Golang-application-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Update the CLI name from "microservice-cli" to "github.com/ElouanDaCosta/Golang-application-cli" and update the descriptions for the commands "init", "list", "remove", and "upgrade" to provide more clarity and examples.