### PR TITLE
Refactor remove command and update version to 0.11

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,7 +24,6 @@ type Folder struct {
 
 type Config struct {
 	ServiceName string   `mapstructure:"service_name"`
-	Port        int      `mapstructure:"port"`
 	Folders     []Folder `mapstructure:"folders"`
 }
 
@@ -58,7 +57,7 @@ func generateFromStructureFile(appName string) {
 	stdout, newServiceErr := newService.Output()
 
 	if newServiceErr != nil {
-		fmt.Println(newServiceErr.Error())
+		fmt.Println("Error creating the directory:", newServiceErr.Error())
 		return
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -209,11 +209,11 @@ func writeMainGo(basePath string, appType string) {
 
 	switch appType {
 	case "gin":
-		content = fmt.Sprintf(templates.RenderGinTemplate())
+		content = fmt.Sprintf("%v", templates.RenderGinTemplate())
 	case "gRPC":
-		content = fmt.Sprintf(templates.RenderGrpcTemplate())
+		content = fmt.Sprintf("%v", templates.RenderGrpcTemplate())
 	case "basic http":
-		content = fmt.Sprintf(templates.RenderHttpTemplate())
+		content = fmt.Sprintf("%v", templates.RenderHttpTemplate())
 	}
 
 	_, err = f.WriteString(content)

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -16,20 +16,20 @@ import (
 
 // removeCmd represents the remove command
 var removeCmd = &cobra.Command{
-	Use:   "remove",
+	Use:   "prune",
 	Short: "Remove an application from the storage",
 	Long: `Remove an application from the storage,
 clear completely the storage where all the application is saved 
 or remove an application with the remove-app flag. For example:
 
-go-app-cli remove --name new_app
-go-app-cli remove --prune
-go-app-cli remove --remove-app --name new_app
+go-app-cli prune --name new_app
+go-app-cli prune --all
+go-app-cli prune --app --name new_app
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		appName, _ := cmd.Flags().GetString("name")
-		clearAllApp, _ := cmd.Flags().GetBool("prune")
-		removeApp, _ := cmd.Flags().GetBool("remove-app")
+		clearAllApp, _ := cmd.Flags().GetBool("all")
+		removeApp, _ := cmd.Flags().GetBool("app")
 
 		if appName != "" {
 			if removeApp {
@@ -187,6 +187,6 @@ func init() {
 	// is called directly, e.g.:
 	// removeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	removeCmd.PersistentFlags().String("name", "", "Clear the given application from the saved application storage")
-	removeCmd.Flags().BoolP("prune", "p", false, "Clear all the storage from the saved application.")
-	removeCmd.Flags().BoolP("remove-app", "r", false, "Delete the working directory of the given application. Not reversible !")
+	removeCmd.Flags().BoolP("all", "a", false, "Clear all the storage from the saved application.")
+	removeCmd.Flags().BoolP("app", "r", false, "Delete the working directory of the given application. Not reversible !")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.10",
+	Version: "0.11",
 	Use:     "go-app-cli",
 	Short:   "Generate a basic template of an application in Golang",
 	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.9",
+	Version: "0.10",
 	Use:     "go-app-cli",
 	Short:   "Generate a basic template of an application in Golang",
 	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,6 +4,7 @@ Copyright © 2024 Elouan DA COSTA PEIXOTO elouandacostapeixoto@gmail.com
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -28,14 +29,24 @@ go-app-cli upgrade --newversion [version_wanted] -a
 		newVersion, _ := cmd.Flags().GetString("newversion")
 		allApp, _ := cmd.Flags().GetBool("all")
 
-		if name != "" && newVersion != "" {
-			appPath := getAppPath(name)
-			bumpOneGoVersion(appPath, newVersion)
-		} else if newVersion != "" && allApp {
-			appPath := getAllPath()
-			bumpAllGoVersion(appPath, newVersion)
-		} else if newVersion != "" && !allApp {
-			log.Println("Use the all flag or specified an application name")
+		if name != "" {
+			if newVersion != "" {
+				appPath := getAppPath(name)
+				bumpOneGoVersion(appPath, newVersion)
+			} else {
+				fmt.Println("Please refer a new version for your application")
+			}
+			return
+		}
+		if newVersion != "" {
+			if allApp {
+				appPath := getAllPath()
+				bumpAllGoVersion(appPath, newVersion)
+			} else {
+				fmt.Println("Use the all flag or specified an application name")
+			}
+		} else {
+			fmt.Println("Please refer a new version or use a different flag")
 		}
 	},
 }


### PR DESCRIPTION
The remove command has been refactored to be renamed as prune, and the flags have been updated accordingly. The condition for the different flags for the upgrade command has been improved. Additionally, the version of the CLI has been bumped to 0.11.