### PR TITLE
Add GetInstalledPath and GetAbsolutePath functions

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/ElouanDaCosta/Golang-application-cli/templates"
 	"github.com/ElouanDaCosta/Golang-application-cli/utils"
@@ -86,7 +85,7 @@ func generateFromStructureFile(appName string) {
 	log.Println("Application structure created")
 	addPackageToApp(newAppType, appName)
 
-	writeInSaveAppFile(appName, installedPath)
+	writeInSaveAppFile(appName, installedPath, currentPath)
 
 	fmt.Printf("Microservice %s created successfully\n", appName)
 }
@@ -179,7 +178,7 @@ func addPackageToApp(appType string, newAppBasePath string) {
 	}
 }
 
-func writeInSaveAppFile(appName string, basePath string) {
+func writeInSaveAppFile(appName string, basePath string, currentPath string) {
 	os.Chdir(basePath + "/storage")
 	f, err := os.OpenFile("app.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -191,13 +190,7 @@ func writeInSaveAppFile(appName string, basePath string) {
 		log.Fatal(err)
 	}
 
-	absolutePathApp, err := filepath.Abs("../" + appName)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	f.Write([]byte("app path: " + absolutePathApp + "\n\n"))
+	f.Write([]byte("app path: " + currentPath + "/" + appName + "\n\n"))
 
 	f.Close()
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -61,8 +61,6 @@ func generateFromStructureFile(appName string) {
 		return
 	}
 
-	installedPath := utils.GetInstalledPath()
-
 	currentPath := utils.GetAbsolutePath()
 
 	if err := os.Chdir(appName); err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,8 +9,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ElouanDaCosta/Golang-application-cli/utils"
 	"github.com/spf13/cobra"
 )
+
+var installedPath = utils.GetInstalledPath()
 
 // getCmd represents the get command
 var listCmd = &cobra.Command{
@@ -32,7 +35,7 @@ go-app-cli list --name [your_app_name]
 }
 
 func listAllApp() {
-	os.Chdir("./storage")
+	os.Chdir(installedPath + "/storage")
 	f, err := os.ReadFile("app.txt")
 	if err != nil {
 		log.Println(err)
@@ -41,7 +44,7 @@ func listAllApp() {
 }
 
 func getOneApp(appName string) {
-	os.Chdir("./storage")
+	os.Chdir(installedPath + "/storage")
 	f, err := os.ReadFile("app.txt")
 	if err != nil {
 		log.Println(err)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,11 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ElouanDaCosta/Golang-application-cli/utils"
 	"github.com/spf13/cobra"
 )
-
-var installedPath = utils.GetInstalledPath()
 
 // getCmd represents the get command
 var listCmd = &cobra.Command{

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -50,7 +50,7 @@ go-app-cli prune --app --name new_app
 }
 
 func removeFromStorage(appName string) {
-	os.Chdir("./storage")
+	os.Chdir(installedPath + "/storage")
 
 	filePath := "app.txt"
 	targetLine := appName
@@ -102,7 +102,7 @@ func removeFromStorage(appName string) {
 }
 
 func cleanAllStorage() {
-	os.Chdir("./storage")
+	os.Chdir(installedPath + "/storage")
 
 	f, err := os.OpenFile("app.txt", os.O_RDWR, 0644)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,11 @@ package cmd
 import (
 	"os"
 
+	"github.com/ElouanDaCosta/Golang-application-cli/utils"
 	"github.com/spf13/cobra"
 )
+
+var installedPath = utils.GetInstalledPath()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -80,7 +80,7 @@ func bumpAllGoVersion(appPath []string, newVersion string) {
 
 func getAllPath() []string {
 	var outpout []string
-	os.Chdir("./storage")
+	os.Chdir(installedPath + "/storage")
 	f, err := os.ReadFile("app.txt")
 	if err != nil {
 		log.Println(err)
@@ -95,7 +95,7 @@ func getAllPath() []string {
 }
 
 func getAppPath(appName string) string {
-	os.Chdir("./storage")
+	os.Chdir(installedPath + "/storage")
 	f, err := os.ReadFile("app.txt")
 	if err != nil {
 		log.Println(err)

--- a/utils/path.go
+++ b/utils/path.go
@@ -3,29 +3,18 @@ package utils
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
-func GetAbsolutePath(filePath string) string {
-	// Getting absolute path of hello.go
-	abs, err := filepath.Abs(filePath)
+func GetAbsolutePath() string {
+	// Getting absolute path of current directory
+	abs, err := filepath.Abs(".")
 
 	// Printing if there is no error
 	if err != nil {
 		fmt.Println("Error getting the absolute path: ", err)
 	}
 	return abs
-}
-
-func RunProgram(program string) string {
-	a := strings.Split(program, " ")
-	out, err := exec.Command(a[0], a[1:]...).Output()
-	if err != nil {
-		panic(err)
-	}
-	return string(out)
 }
 
 func GetInstalledPath() string {

--- a/utils/path.go
+++ b/utils/path.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func GetAbsolutePath(filePath string) string {
+	// Getting absolute path of hello.go
+	abs, err := filepath.Abs(filePath)
+
+	// Printing if there is no error
+	if err != nil {
+		fmt.Println("Error getting the absolute path: ", err)
+	}
+	return abs
+}
+
+func RunProgram(program string) string {
+	a := strings.Split(program, " ")
+	out, err := exec.Command(a[0], a[1:]...).Output()
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+func GetInstalledPath() string {
+	// getting the environment variable of the installed path of the cli
+	getPathEnv, exists := os.LookupEnv("GAC")
+	if !exists {
+		fmt.Println("Error reading GAC variables")
+		return ""
+	}
+	return getPathEnv
+}


### PR DESCRIPTION
This pull request adds two new functions, `GetInstalledPath` and `GetAbsolutePath`, to the codebase. These functions are utility functions that provide the absolute path of the current directory and the installed path of the CLI, respectively. These functions are useful for various operations within the codebase.

Now all the commands can be use anywhere using the wanted features and structure from the CLI.

The CLI now knows its own installation path and the path in which a command is currently execute, making it independant of the current working directory.