### PR TITLE
Update Dockerfile template and CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ You can create a dockerfile for the application using the following command.
 ./bin/go-app-cli init --name <YOUR_APP_NAME> --dockerfile
 ```
 
+The dockerfile will be created in the root of the application and the Golang version will be the same as the application.
+
 ### List applications
 
 List all the applications using the following command.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/ElouanDaCosta/Golang-application-cli/templates"
 	"github.com/ElouanDaCosta/Golang-application-cli/utils"
@@ -214,7 +215,15 @@ func createDockerfile(appName string) {
 		return
 	}
 
-	var content = fmt.Sprintf("%v", templates.RenderDockerfileTemplate())
+	appVersion, err := utils.GetGoVersion(appName)
+
+	appVersionSplit := strings.Split(appVersion, " ")
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var content = fmt.Sprintf("%v", templates.RenderDockerfileTemplate(appVersionSplit[1]))
 
 	_, err = f.WriteString(content)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var installedPath = utils.GetInstalledPath()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "1.1.0",
+	Version: "1.2.0",
 	Use:     "go-app-cli",
 	Short:   "Generate a basic template of an application in Golang",
 	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,

--- a/templates/docker.template.go
+++ b/templates/docker.template.go
@@ -1,7 +1,9 @@
 package templates
 
-func RenderDockerfileTemplate() string {
-	const dockerTemplate = `FROM golang:latest
+import "fmt"
+
+func RenderDockerfileTemplate(version string) string {
+	const dockerTemplate = `FROM golang:%v
 
 WORKDIR /app
 
@@ -17,5 +19,5 @@ EXPOSE 8080
 
 CMD ["/docker-gs-ping"]`
 
-	return dockerTemplate
+	return fmt.Sprintf(dockerTemplate, version)
 }

--- a/utils/app-version.go
+++ b/utils/app-version.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func GetGoVersion(appPath string) (string, error) {
+	os.Chdir(appPath)
+	f, err := os.ReadFile("go.mod")
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+
+	lines := strings.Split(string(f), "\n")
+
+	versionSplit := strings.Split(lines[2], "go")
+
+	return versionSplit[1], nil
+}


### PR DESCRIPTION
This pull request includes several commits that update the Dockerfile template and CLI version. The Dockerfile template has been modified to accept a variable for the Golang version, which is now set to the same version as the application. Additionally, the CLI version has been bumped from 1.1.0 to 1.2.0. The README has also been updated to reflect the changes in the Dockerfile flag.