### PR TITLE
Add Dockerfile generation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ You can create a dockerfile for the application using the following command.
 ./bin/go-app-cli init --name <YOUR_APP_NAME> --dockerfile
 ```
 
+The dockerfile will be created in the root of the application and the Golang version will be the same as the application.
+
 ### List applications
 
 List all the applications using the following command.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Create a new application using the following command.
 ./bin/go-app-cli init --name <YOUR_APP_NAME>
 ```
 
+You can create a dockerfile for the application using the following command.
+
+```bash
+./bin/go-app-cli init --name <YOUR_APP_NAME> --dockerfile
+```
+
 ### List applications
 
 List all the applications using the following command.
@@ -138,5 +144,5 @@ Update the go version of all the applications using the following command.
 2. **cmd**: Contains the commands for the CLI.
 3. **configs**: Contains the configuration files for application structure that the CLI generate.
 4. **storage**: Contains the storage files for the CLI.
-5. **templates**: Contains the templates for main.go that the CLI generate.
+5. **templates**: Contains the templates for main.go and dockerfiles that the CLI generate.
 6. **utils**: Contains the utility functions for the CLI.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/ElouanDaCosta/Golang-application-cli/templates"
 	"github.com/ElouanDaCosta/Golang-application-cli/utils"
@@ -214,7 +215,15 @@ func createDockerfile(appName string) {
 		return
 	}
 
-	var content = fmt.Sprintf("%v", templates.RenderDockerfileTemplate())
+	appVersion, err := utils.GetGoVersion(appName)
+
+	appVersionSplit := strings.Split(appVersion, " ")
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var content = fmt.Sprintf("%v", templates.RenderDockerfileTemplate(appVersionSplit[1]))
 
 	_, err = f.WriteString(content)
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -43,16 +43,21 @@ go-app-cli init --name [your_app_name]
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		appName, _ := cmd.Flags().GetString("name")
+		dockerfile, _ := cmd.Flags().GetBool("dockerfile")
 
 		if appName != "" {
-			generateFromStructureFile(appName)
+			if dockerfile {
+				generateFromStructureFile(appName, true)
+			} else {
+				generateFromStructureFile(appName, false)
+			}
 		} else {
-			generateFromStructureFile("new_app")
+			generateFromStructureFile("new_app", false)
 		}
 	},
 }
 
-func generateFromStructureFile(appName string) {
+func generateFromStructureFile(appName string, dockerfile bool) {
 	newService := exec.Command("mkdir", appName)
 	_, newServiceErr := newService.Output()
 
@@ -82,10 +87,13 @@ func generateFromStructureFile(appName string) {
 	createFolders(currentPath+"/"+appName, config.Folders)
 	log.Println("Application structure created")
 	addPackageToApp(newAppType, appName)
+	if dockerfile {
+		createDockerfile(currentPath + "/" + appName)
+	}
 
 	writeInSaveAppFile(appName, installedPath, currentPath)
 
-	fmt.Printf("Microservice %s created successfully\n", appName)
+	fmt.Printf("%s created successfully\n", appName)
 }
 
 func runGoModInit(serviceName string) {
@@ -193,6 +201,30 @@ func writeInSaveAppFile(appName string, basePath string, currentPath string) {
 	f.Close()
 }
 
+func createDockerfile(appName string) {
+	errWd := os.Chdir(appName)
+
+	if errWd != nil {
+		fmt.Println(errWd)
+	}
+
+	f, err := os.OpenFile("dockerfile", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var content = fmt.Sprintf("%v", templates.RenderDockerfileTemplate())
+
+	_, err = f.WriteString(content)
+
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		log.Println("dockerfile generated successfully.")
+	}
+}
+
 func writeMainGo(basePath string, appType string) {
 	os.Chdir(basePath)
 	f, err := os.OpenFile("main.go", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
@@ -217,11 +249,12 @@ func writeMainGo(basePath string, appType string) {
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		fmt.Println("main.go generated successfully.")
+		log.Println("main.go generated successfully.")
 	}
 }
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
 	generateCmd.PersistentFlags().String("name", "", "Generate an app with the given name (default new_app)")
+	generateCmd.Flags().BoolP("dockerfile", "d", false, "Generate a dockerfile in the new app directory")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var installedPath = utils.GetInstalledPath()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "1.0.2",
+	Version: "1.1.2",
 	Use:     "go-app-cli",
 	Short:   "Generate a basic template of an application in Golang",
 	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var installedPath = utils.GetInstalledPath()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "1.1.2",
+	Version: "1.1.0",
 	Use:     "go-app-cli",
 	Short:   "Generate a basic template of an application in Golang",
 	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@ var installedPath = utils.GetInstalledPath()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "1.1.0",
+	Version: "1.2.0",
 	Use:     "go-app-cli",
 	Short:   "Generate a basic template of an application in Golang",
 	Long:    `Generate template for applications in Golang with the package that you want, like gin, gRPC etc.`,

--- a/templates/docker.template.go
+++ b/templates/docker.template.go
@@ -1,7 +1,9 @@
 package templates
 
-func RenderDockerfileTemplate() string {
-	const dockerTemplate = `FROM golang:latest
+import "fmt"
+
+func RenderDockerfileTemplate(version string) string {
+	const dockerTemplate = `FROM golang:%v
 
 WORKDIR /app
 
@@ -17,5 +19,5 @@ EXPOSE 8080
 
 CMD ["/docker-gs-ping"]`
 
-	return dockerTemplate
+	return fmt.Sprintf(dockerTemplate, version)
 }

--- a/templates/docker.template.go
+++ b/templates/docker.template.go
@@ -1,0 +1,21 @@
+package templates
+
+func RenderDockerfileTemplate() string {
+	const dockerTemplate = `FROM golang:latest
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY *.go ./
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /docker-gs-ping
+
+EXPOSE 8080
+
+CMD ["/docker-gs-ping"]`
+
+	return dockerTemplate
+}

--- a/utils/app-version.go
+++ b/utils/app-version.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func GetGoVersion(appPath string) (string, error) {
+	os.Chdir(appPath)
+	f, err := os.ReadFile("go.mod")
+	if err != nil {
+		fmt.Println(err)
+		return "", err
+	}
+
+	lines := strings.Split(string(f), "\n")
+
+	versionSplit := strings.Split(lines[2], "go")
+
+	return versionSplit[1], nil
+}


### PR DESCRIPTION
This pull request adds the functionality to generate a Dockerfile for the application. It includes the following changes:

- Added a template for the Dockerfile

- Added the `createDockerfile` function and updated the `init` command to generate the Dockerfile

- Bumped the CLI version from 1.0.2 to 1.1.2

- Fixed the version of the CLI

- Updated the documentation for the `--dockerfile` flag in the `init` command

- Updated the Dockerfile template to accept a variable

- Added the `app-version` utils with the `GetGoVersion` function

- Updated the `createDockerfile` function to create the Dockerfile with the same Go version as the application

- Bumped the CLI version from 1.1.0 to 1.2.0

- Updated the README for the Dockerfile flag